### PR TITLE
Fix setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,6 @@
 pip install poetry
 poetry install
 poetry run playwright install
-docker compose run -d
+docker compose up -d
 
 echo "BeeBot is now set up"


### PR DESCRIPTION
I believe there is a typo in setup.sh. docker-compose run typically requires a service name, and it currently errors out. 

@erik-megarad lmk what do you think