### PR TITLE
#17: Fail fast when migrations dir cannot be resolved

### DIFF
--- a/beebot/models/database_models.py
+++ b/beebot/models/database_models.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from tortoise import fields, Tortoise
 from tortoise.fields import JSONField, BooleanField
@@ -124,7 +125,11 @@ def apply_migrations(db_url: str):
     """Apply any outstanding migrations"""
     backend = get_backend(db_url)
     backend.init_database()
-    migrations = read_migrations("migrations")
+    migrations_dir = "migrations"
+    if not Path(migrations_dir).exists():
+        raise FileNotFoundError(f"\"{migrations_dir}\" directory not found. "
+                                "Make sure to set working directory to the root of the project")
+    migrations = read_migrations(migrations_dir)
 
     with backend.lock():
         backend.apply_migrations(backend.to_apply(migrations))


### PR DESCRIPTION
tl;dr; Mitigates the issue: https://github.com/AutoPackAI/beebot/issues/17

**Details:**
When application is running by IDE generated quick run play button:
![зображення](https://github.com/AutoPackAI/beebot/assets/4522842/68464233-4069-41f6-b764-d920c577368f)

It automatically sets working directory to `beebot/initiator` sub-directory of the repository, because such entry point is located in that directory. At the same time, when `yoyo` reads migrations:
```python
migrations = read_migrations("migrations")
```
it does use relative to the working directory path, however, even if such path does not exist, the library silently returns empty MigrationList:
![зображення](https://github.com/AutoPackAI/beebot/assets/4522842/87fc0387-16af-4aac-a3bf-2767bab24a2e)
which leads to missing schema and fails later in the code path that accesses the entity.

This approach fails fast preventing application from running on the unexpected working directory.

Alternative approach would be to resolve migrations directory relative to `database_models.py`:
```python
    migrations_dir = "migrations"
    models_dir = os.path.dirname(__file__)
    migrations = Path(models_dir).parent.parent.resolve().joinpath(migrations_dir).absolute()
    if not migrations.exists():
        raise FileNotFoundError(f"\"{migrations_dir}\" directory not found. ")
    migrations_dir = str(migrations)
    migrations = read_migrations(migrations_dir)
```
With this approach the part responsible for migrations will successfully locate migrations in regardless of working directory:
![зображення](https://github.com/AutoPackAI/beebot/assets/4522842/8b9303f9-ea75-4020-a6d2-6d31111ef5b3)
At the same time, the code becomes coupled to the `database_models.py` and `migrations` locations and also does not fix possibility for other places in code to rely on the repository layout.

Best practice in general would be to locate migrations within source code module, so it can be referenced from the source code root as python modules do right now.

Please let me know if this simple fail fast solution enough or you prefer anything else. 

